### PR TITLE
Mobile inference

### DIFF
--- a/JETSON_INSTALL.md
+++ b/JETSON_INSTALL.md
@@ -1,0 +1,33 @@
+
+# Setup on Jeston Nano
+
+The install instructions below have been tested on the 4 GB original (pre-Orin) Jetson Nano developer kit.
+
+```
+# install latest pip
+sudo apt-get install -y python3-pip
+pip3 install --upgrade pip
+
+# install torch v1.10.0
+cd ~
+sudo apt-get install -y libopenblas-base libopenmpi-dev
+wget https://nvidia.box.com/shared/static/fjtbno0vpo676a25cgvuqc1wty0fkkg6.whl -O torch-1.10.0-cp36-cp36m-linux_aarch64.whl
+pip3 install torch-1.10.0-cp36-cp36m-linux_aarch64.whl
+
+# install torchvision v0.11.0 (takes 1 hr to build)
+sudo apt install -y libjpeg-dev zlib1g-dev
+git clone --branch v0.11.0 https://github.com/pytorch/vision torchvision
+cd torchvision
+pip3 install .
+
+# install requirements (takes at least 1 hr to build opencv)
+pip3 install -r jetson_nano_requirements.txt
+
+# add Python executables to PATH to use gdown
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc 
+source ~/.bashrc
+
+# apply numpy architecture fix to avoid segfault
+echo 'export OPENBLAS_CORETYPE=ARMV8' >> ~/.bashrc
+source ~/.bashrc
+```

--- a/JETSON_INSTALL.md
+++ b/JETSON_INSTALL.md
@@ -1,7 +1,7 @@
 
 # Setup on Jeston Nano
 
-The install instructions below have been tested on the 4 GB original (pre-Orin) Jetson Nano developer kit.
+The install instructions below have been tested on the 4 GB original (pre-Orin) Jetson Nano developer kit. The PyTorch installation instructions are adapted from [here](https://docs.ultralytics.com/yolov5/jetson_nano/#install-pytorch-and-torchvision).
 
 ```
 # install latest pip

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ We extend the MaSTr1325 dataset by providing the context frames (5 preceding fra
 ## Mobile WaSR-T
 *Contributed by @playertr*
 
-To enable the inference on devices with limited memory and compute resources, a light-weight, reduced-resolution version of WaSR-T has been trained. The mobile WaSR-T runs on the Jetson Nano embedded platform at around 13 FPS. Follow the [installation instructions](JETSON_INSTALL.MD) for a setup that has been tested on the 4GB original (pre-Orin) Jetson Nano developer kit.
+To enable the inference on devices with limited memory and compute resources, a light-weight, reduced-resolution version of WaSR-T has been trained. The mobile WaSR-T runs on the Jetson Nano embedded platform at around 13 FPS. Follow the [installation instructions](JETSON_INSTALL.md) for a setup that has been tested on the 4GB original (pre-Orin) Jetson Nano developer kit.
 
 To use or train the mobile version of WaSR-T use the `--mobile` and `--size 256 192` arguments in the training and inference scripts. For example to run the inference using the provided mobile weights and the `predict_sequential.py` script use the following.
 
@@ -157,7 +157,7 @@ We also provide an [example script](predict_gstreamer.py) for inference using a 
 python predict_gstreamer.py --weights path/to/weights.pth --fp16 --mobile --size 256 192
 ```
 
-### Model weights
+### Mobile weights
 
 Pre-trained model weights for the mobile version of WaSR-T. Performance is reported on the MODS dataset.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ python predict_sequential.py \
 --size 256 192
 ```
 
-We also provide an [example script](predict_gstreamer.py) for inference using a *gstreamer* pipeline.
+We also provide an [example script](predict_gstreamer.py) for inference using a *gstreamer* pipeline. By modifying the gstreamer pipeline the live segmentation results can be sent to other destinations for processing.
 
 ```bash
 python predict_gstreamer.py --weights path/to/weights.pth --fp16 --mobile --size 256 192

--- a/README.md
+++ b/README.md
@@ -157,3 +157,20 @@ If you use this code, please cite our paper:
 <a name="ref-wasr"></a>[3] Bovcon, B., & Kristan, M. (2021). WaSR--A Water Segmentation and Refinement Maritime Obstacle Detection Network. IEEE Transactions on Cybernetics
 
 <a name="ref-mods"></a>[4] Bovcon, B., Muhovič, J., Vranac, D., Mozetič, D., Perš, J., & Kristan, M. (2021). MODS -- A USV-oriented object detection and obstacle segmentation benchmark.
+
+
+## Mobile Inference
+These steps are relevant for the mobile inference neural network, which functions identically but has fewer parameters and is suitable for lower-resolution inference on the Jetson Nano.
+```
+# install requirements
+pip3 install -r requirements.txt
+
+# download weights (with gdown installed)
+gdown https://drive.google.com/file/d/1zU_9Ut5movnX8pI4XTOvfEBSQbgMZdvA
+
+# begin mobile inference (on folder dataset)
+python3 predict_sequential.py --weights lraspp_weights.ckpt --sequence-dir MaSTr153 --output-dir output --mobile
+
+# begin mobile inference (through gstreamer pipeline)
+python3 predict_gstreamer.py --weights lraspp_weights.ckpt
+```

--- a/README.md
+++ b/README.md
@@ -195,12 +195,12 @@ source ~/.bashrc
 
 # begin mobile inference (through gstreamer pipeline)
 # this takes in the camera stream and writes it to a file "out.flv"
-python3 predict_gstreamer.py --weights lraspp_weights.ckpt --fp16
+python3 predict_gstreamer.py --weights lraspp_weights.ckpt --fp16 --mobile --size 256 192
 ```
 
 The `predict_sequential.py` script can also be used on the mobile inference network as follows.
 ```
 # begin mobile inference (on folder dataset)
 # this functions similarly to predict_sequential.py on the full network
-python3 predict_sequential.py --weights lraspp_weights.ckpt --sequence-dir MaSTr153 --output-dir output --mobile --fp16
+python3 predict_sequential.py --weights lraspp_weights.ckpt --sequence-dir MaSTr153 --output-dir output --mobile --fp16 --size 256 192
 ``` 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ We extend the MaSTr1325 dataset by providing the context frames (5 preceding fra
 - MaSTr1478 extension data: [link](https://github.com/lojzezust/WaSR-T/releases/download/weights/mastr153.zip)
 
 ## Mobile WaSR-T
-*Contributed by @playertr*
+*Contributed by [@playertr](https://github.com/playertr)*
 
 To enable the inference on devices with limited memory and compute resources, a light-weight, reduced-resolution version of WaSR-T has been trained. The mobile WaSR-T runs on the Jetson Nano embedded platform at around 13 FPS. Follow the [installation instructions](JETSON_INSTALL.md) for a setup that has been tested on the 4GB original (pre-Orin) Jetson Nano developer kit.
 

--- a/jetson_nano_requirements.txt
+++ b/jetson_nano_requirements.txt
@@ -1,0 +1,7 @@
+torch
+torchvision
+pytorch-lightning==1.4.4
+torchmetrics==0.5.0
+tqdm
+albumentations
+gdown

--- a/predict_gstreamer.py
+++ b/predict_gstreamer.py
@@ -138,7 +138,7 @@ def main():
             toc = time.time()
             print(f"\rInstantaneous FPS {(1.0 / (toc - tic)) :.2f}.", end='')
             tic = toc
-        cv2.waitKey(1)
+        time.sleep(0.0001)
     
     print("Video capture is closed.")
 

--- a/predict_gstreamer.py
+++ b/predict_gstreamer.py
@@ -1,0 +1,150 @@
+import argparse
+import numpy as np
+import torch
+import torchvision.transforms.functional as TF
+from torchvision.transforms import InterpolationMode, functional as TF
+import cv2
+import time
+
+from wasr_t.data.transforms import PytorchHubNormalization
+from wasr_t.mobile_wasr_t import  wasr_temporal_lraspp_mobilenetv3
+from wasr_t.utils import load_weights
+
+width = 256
+height = 192
+fps = int(30)
+
+# Colors corresponding to each segmentation class
+SEGMENTATION_COLORS = np.array([
+    [247, 195, 37],
+    [41, 167, 224],
+    [90, 75, 164]
+], np.uint8)
+
+HIST_LEN = 5
+
+def get_arguments():
+    """Parse all the arguments provided from the CLI.
+
+    Returns:
+      A list of parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description="WaSR Network Sequential Inference")
+    parser.add_argument("--hist-len", default=HIST_LEN, type=int,
+                        help="Number of past frames to be considered in addition to the target frame (context length). Must match the value used in training.")
+    parser.add_argument("--weights", type=str, required=True,
+                        help="Model weights file.")
+    parser.add_argument("--fp16", action='store_true',
+                        help="Use half precision for inference.")
+    parser.add_argument("--gpus", default=-1,type=int,
+                        help="Number of gpus (or GPU ids) used for training.")
+    return parser.parse_args()
+
+def get_gstream_input() -> cv2.VideoCapture:
+
+    # pipeline from webcam
+    pipeline = f"v4l2src device=/dev/video0 ! video/x-raw,width=640,height=480,framerate={fps}/1 ! videoconvert ! videoscale ! video/x-raw,format=BGR,width={width},height={height} ! appsink drop=true"
+
+    # pipeline from local video
+    # pipeline = f"filesrc location=MaSTr1325/images/wasrt_mobilenetv3_input.webm ! matroskademux ! vp9dec ! videoconvert ! videoscale ! video/x-raw,format=BGR,width={width},height={height} ! appsink drop=true"
+
+    cap = cv2.VideoCapture(pipeline, cv2.CAP_GSTREAMER)
+    return cap
+
+def get_gstream_output() -> cv2.VideoWriter:
+    pipeline_s = "appsrc ! videoconvert ! autovideosink sync=false"
+    # pipeline_s = "appsrc ! videoconvert ! x264enc ! flvmux ! filesink location=out.flv"
+    out = cv2.VideoWriter(pipeline_s,cv2.CAP_GSTREAMER, 0, fps, (width, height), True) 
+    return out
+
+def get_model(args):
+    model = wasr_temporal_lraspp_mobilenetv3(pretrained=False, hist_len=args.hist_len, sequential=True)
+    state_dict = load_weights(args.weights)
+
+    # if PyTorch 2.0's torch.compile() function generated these weights, then we need to remove
+    # the _orig_mod label from each parameter.
+    state_dict = {key.replace("_orig_mod.", "") : value for key, value in state_dict.items()}
+
+    model.load_state_dict(state_dict)
+    model = model.sequential()
+    model = model.eval()
+
+    if args.fp16:
+        model = model.half()
+
+    device = torch.device('cpu') if args.gpus == 0 else torch.device('cuda')
+    model = model.to(device)
+    model.device = device
+
+    model.backbone = torch.jit.optimize_for_inference(torch.jit.script(model.backbone))
+    model.decoder.arm1 = torch.jit.optimize_for_inference(torch.jit.script(model.decoder.arm1))
+    model.decoder.arm2 = torch.jit.optimize_for_inference(torch.jit.script(model.decoder.arm2))
+    model.decoder.ffm = torch.jit.optimize_for_inference(torch.jit.script(model.decoder.ffm))
+    model.decoder.aspp = torch.jit.optimize_for_inference(torch.jit.script(model.decoder.aspp))
+
+    return model
+
+class Inferencer:
+
+    def __init__(self, model):
+        self.model = model
+
+        if any(p.dtype is torch.float16 for p in self.model.parameters()):
+            self.dtype = torch.float16
+        else:
+            self.dtype = torch.float32
+
+    def process_frame(self, frame : np.ndarray):
+
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        tf = PytorchHubNormalization()
+        frame = tf(frame)
+
+        frame = torch.Tensor(frame).to(self.model.device).to(self.dtype)
+        frame = frame.unsqueeze(0)
+
+        with torch.inference_mode():
+            probs = self.model({'image': frame})['out']
+        
+        probs = TF.resize(probs, (height, width), interpolation=InterpolationMode.BILINEAR)
+        out_class = probs.argmax(1).to(torch.uint8).squeeze().detach().cpu().numpy()
+        pred_mask = SEGMENTATION_COLORS[out_class]
+        pred_mask = cv2.cvtColor(pred_mask, cv2.COLOR_RGB2BGR)
+        return pred_mask
+
+def main():
+
+    args = get_arguments()
+    print(f"Got arguments: {args}")
+
+    print("Initializing GStreamer input.")
+    cap = get_gstream_input()
+
+    print("Initializing GStreamer output.")
+    out = get_gstream_output()
+
+    print("Instantiating and compiling model.")
+    model = get_model(args)
+    inferencer = Inferencer(model)
+
+    print("Beginning inference.")
+
+    tic = time.time()
+    while cap.isOpened():
+        ret, frame = cap.read()
+        if ret:
+            frame = inferencer.process_frame(frame)
+            out.write(frame)
+            toc = time.time()
+            print(f"\rInstantaneous FPS {(1.0 / (toc - tic)) :.2f}.", end='')
+            tic = toc
+        cv2.waitKey(1)
+    
+    print("Video capture is closed.")
+
+    # Release everything if job is finished
+    cap.release()
+    out.release()
+
+if __name__ == '__main__':
+    main()

--- a/predict_gstreamer.py
+++ b/predict_gstreamer.py
@@ -52,8 +52,8 @@ def get_gstream_input() -> cv2.VideoCapture:
     return cap
 
 def get_gstream_output() -> cv2.VideoWriter:
-    pipeline_s = "appsrc ! videoconvert ! autovideosink sync=false"
-    # pipeline_s = "appsrc ! videoconvert ! x264enc ! flvmux ! filesink location=out.flv"
+    # pipeline_s = "appsrc ! videoconvert ! autovideosink sync=false"
+    pipeline_s = "appsrc ! videoconvert ! x264enc ! flvmux ! filesink location=out.flv"
     out = cv2.VideoWriter(pipeline_s,cv2.CAP_GSTREAMER, 0, fps, (width, height), True) 
     return out
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-torch==1.8.1
-torchvision==0.9.1
+torch==1.13.1
+torchvision==0.14.1
 pytorch-lightning==1.4.4
 torchmetrics==0.5.0
 tqdm
 albumentations
+gdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-torch==1.13.1
-torchvision==0.14.1
+torch==1.8.1
+torchvision==0.9.1
 pytorch-lightning==1.4.4
 torchmetrics==0.5.0
 tqdm
 albumentations
-gdown

--- a/train.py
+++ b/train.py
@@ -26,7 +26,7 @@ DEVICE_BATCH_SIZE = 3
 TRAIN_CONFIG = 'configs/mastr1325_train.yaml'
 VAL_CONFIG = 'configs/mastr1325_val.yaml'
 NUM_CLASSES = 3
-PATIENCE = 5
+PATIENCE = None
 LOG_STEPS = 20
 NUM_WORKERS = 1
 NUM_GPUS = -1 # All visible GPUs
@@ -41,7 +41,7 @@ ADDITONAL_SAMPLES_RATIO = 0.5
 
 HIST_LEN = 5
 BACKBONE_GRAD_STEPS = 2
-SIZE = (384,512)
+SIZE = (512,384)
 
 def get_arguments(input_args=None):
     """Parse all the arguments provided from the CLI.

--- a/train.py
+++ b/train.py
@@ -41,6 +41,7 @@ ADDITONAL_SAMPLES_RATIO = 0.5
 
 HIST_LEN = 5
 BACKBONE_GRAD_STEPS = 2
+SIZE = (384,512)
 
 def get_arguments(input_args=None):
     """Parse all the arguments provided from the CLI.
@@ -100,15 +101,12 @@ def get_arguments(input_args=None):
                         help="Number of past frames to be considered in addition to the target frame (context length).")
     parser.add_argument("--backbone-grad-steps", default=BACKBONE_GRAD_STEPS, type=int,
                         help="How far into the past the backbone gradients are propagated. 1 means gradients are only propagated through the target frame.")
-
     parser.add_argument("--resume-from", type=str, default=None,
                         help="Resume training from specified checkpoint.")
-    
     parser.add_argument("--mobile", action='store_true',
                     help="Use smaller network network for mobile inference.")
-    
     parser.add_argument("--size", type=int, nargs=2,
-                    help='Resolution used for training, (Width, Height). Used like "--size 384 512".', default=[384,512])
+                    help='Input resolution used for training (Width, Height). Used like "--size 512 384".', default=SIZE)
 
     parser = LitModel.add_argparse_args(parser)
 
@@ -184,11 +182,10 @@ def train_wasrt(args):
     args.random_seed = pl.seed_everything(args.random_seed)
 
     normalize_t = PytorchHubNormalization()
-    if args.mobile:
-        normalize_t = T.Compose([
-            normalize_t,
-            T.Resize(tuple(args.size))
-        ])
+    normalize_t = T.Compose([
+        normalize_t,
+        T.Resize(tuple(args.size[::-1]))
+    ])
     data = DataModule(args, normalize_t)
 
     # Get model

--- a/wasr_t/mobile_wasr_t.py
+++ b/wasr_t/mobile_wasr_t.py
@@ -1,0 +1,104 @@
+"""
+mobile_wasr_t.py
+
+A version of wasr_t modified for inference on an embedded platform.
+
+Identical to wasr_t except:
+ - uses the smaller lrasp_mobilenet_v3 backbone
+ - reduces the latent channel dimension of several elements in the decoder
+ - trained for inference at 192x256 resolution
+
+These changes are implemented as overrides through Python inheritance.
+"""
+
+from wasr_t.wasr_t import *
+from wasr_t.layers import *
+
+from torchvision.models.segmentation import lraspp_mobilenet_v3_large
+
+model_urls = {
+    'lraspp_mobilenet_v3_large' : 'https://download.pytorch.org/models/lraspp_mobilenet_v3_large-d234d4ea.pth'
+}
+
+## Functional network definition
+
+def wasr_temporal_lraspp_mobilenetv3(num_classes=3, pretrained=True, sequential=False, backbone_grad_steps=2, hist_len=5):
+
+    # Pretrained LRASPP mobilenetv3 backbone
+    backbone = lraspp_mobilenet_v3_large()
+
+    # There are five non-convolutional backbone features in MobileNetV3.
+    # 0: Feature 0 is (16, 192, 256)
+    # 1: Feature 2 is (24, 96, 128)
+    # 2: Feature 4 is (40, 48, 64)
+    # 3: Feature 7 is (80, 24, 32).
+    # 4: Feature 13 is (160, 12, 16).
+    # 5: Feature 16 is (960, 12, 16).
+
+    # skip connection locations determined by grad student descent
+    skip1_pos = 2
+    skip2_pos = 4
+    aux_pos = 13
+    out_pos = 16
+
+    return_layers = {
+        str(skip1_pos): "skip1",
+        str(skip2_pos): "skip2",
+        str(aux_pos): "aux",
+        str(out_pos): "out"
+    }
+    return_layers[str(aux_pos)] = "aux"
+
+    backbone = IntermediateLayerGetter(backbone.backbone, return_layers=return_layers)
+
+    decoder = MobileWaSRTDecoder(num_classes, hist_len=hist_len, sequential=sequential)
+
+    model = WaSRT(backbone, decoder, backbone_grad_steps=backbone_grad_steps, sequential=sequential)
+
+    # Load pretrained DeeplabV3 weights (COCO)
+    if pretrained:
+        model_url = model_urls['lraspp_mobilenet_v3_large']
+        state_dict = load_state_dict_from_url(model_url, progress=True)
+
+        # Only load backbone weights, since decoder is entirely different
+        keys_to_remove = [key for key in state_dict.keys() if not key.startswith('backbone.')]
+        for key in keys_to_remove: del state_dict[key]
+
+        model.load_state_dict(state_dict, strict=False)
+
+    return model
+
+## The changes to the decoder follow
+
+class MobileWaSRTDecoder(WaSRTDecoder):
+    """A decoder module with reduced latent dimension, designed to work with wasrt_temporal_mobilenetv3."""
+
+    def __init__(self, num_classes, hist_len=5, sequential=False):
+        super().__init__(num_classes, hist_len, sequential)
+
+        # Temporal Context Module
+        self.tcm = MobileTemporalContextModule(960, hist_len=hist_len, sequential=sequential)
+
+        self.arm1 = L.AttentionRefinementModule(240)
+        self.arm2 = nn.Sequential(
+            L.AttentionRefinementModule(40, last_arm=True),
+            nn.Conv2d(40, 240, 1, 2) # Equalize number of features with ARM1
+        )
+
+        self.ffm = MobileFeatureFusionModule(24, 240, 128)
+        self.aspp = L.ASPPv2(128, [6, 12, 18, 24], num_classes)
+
+class MobileTemporalContextModule(TemporalContextModule):
+    """A temporal context module with reduced latent dimension, designed to work with wasrt_temporal_mobilenetv3."""
+    def __init__(self, in_features, hist_len=5, sequential=False):
+        super().__init__(in_features, hist_len, sequential)
+
+        div = 8 # arbitrary factor to reduce latent dimension, resulting in quadratic reduction of 3D conv complexity
+        self.conv_in = nn.Conv2d(in_features, in_features//div, 1)
+        self.conv_agg = nn.Conv3d(in_features//div, in_features//div, (hist_len+1, 3, 3), padding=(0,1,1))
+
+class MobileFeatureFusionModule(FeatureFusionModule):
+    """A feature fusion module with greater upsampling to account for reduced resolution in intermediate layers."""
+    def __init__(self, bg_channels, sm_channels, num_features):
+        super().__init__(bg_channels, sm_channels, num_features)
+        self.upsampling = nn.UpsamplingNearest2d(scale_factor=4)


### PR DESCRIPTION
This PR addresses https://github.com/lojzezust/WaSR-T/issues/1 by adding and documenting a mobile-optimized version of WaSR-T.

The meat of the changes are in `mobile_wasr_t.py`, which uses Python inheritance to implement a few changes to the network without modifying the original `wasr_t.py` file. These changes are:
 - using the smaller lrasp_mobilenet_v3 backbone
 - reducing the latent channel dimension of several elements in the decoder
 - doing inference at 192x256 resolution

This PR also adds a script for real-time inference using gstreamer, a new `--mobile` flag for `train.py` and `predict_sequential.py`, and a new requirements.txt file specific to the Jetson Nano (which likely has different versions of PyTorch). Documentation for the new features is provided as an addendum to the README.

I'm open to any changes to this PR prior to merging -- in particular, I'd be willing to document the folder structure of the FolderDataset or to sequester all the new changes into a new folder if those would be positive changes.